### PR TITLE
Changed template strings due to deprecation

### DIFF
--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
-    lang="{{ site.Language.LanguageCode }}"
-    dir="{{ or site.Language.LanguageDirection `ltr` }}"
+    lang="{{ site.Language.Locale }}"
+    dir="{{ or site.Language.Direction `ltr` }}"
 >
     <head>
         {{ partial "head.html" . }}


### PR DESCRIPTION
## Changed

Updated `layouts/baseof.html` to replace deprecated Hugo language variables:

- `.Language.LanguageCode` -> `.Language.Locale`
- `.Language.LanguageDirection` -> `.Language.Direction`

## Rationale

These variables were deprecated in Hugo v0.158.0 and are expected to be removed in a future release. This keeps the theme compatible with newer Hugo versions and removes deprecation warnings during builds.